### PR TITLE
simplified modebar and make it always visible

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,7 +78,15 @@ app.layout = html.Div([
             className="pure-u-1 pure-u-lg-1 pure-u-xl-12-24",
             ),
         html.Div([
-            dcc.Graph(id='plot', figure=fig2)
+            dcc.Graph(
+                id='plot', figure=fig2,
+                config={
+                    'displayModeBar': True,
+                    'modeBarButtonsToRemove': ['toImage', 'zoom2d',
+                                               'select2d', 'lasso2d',
+                                               'toggleSpikelines',
+                                               'resetScale2d']}
+                )
             ],
             className="pure-u-1 pure-u-lg-1-2 pure-u-xl-8-24",
             ),

--- a/app.py
+++ b/app.py
@@ -67,7 +67,13 @@ app.layout = html.Div([
     html.H1(children=app.title, className="title"),
     html.Div([#row
         html.Div([
-            dcc.Graph(id='map', figure=fig1)
+            dcc.Graph(
+                id='map', figure=fig1,
+                config={
+                    'displayModeBar': True,
+                    'modeBarButtonsToRemove': ['toImage', 'lasso2d',
+                                               'toggleSpikelines',
+                                               'hoverClosestGeo']})
             ],
             className="pure-u-1 pure-u-lg-1 pure-u-xl-12-24",
             ),

--- a/make_figures.py
+++ b/make_figures.py
@@ -51,7 +51,8 @@ def make_map(df, df_fatalities, df_recovered, pop):
             coloraxis_colorbar_len=0.6,
             coloraxis_colorbar_title_font_size=LABEL_FONT_SIZE,
             margin=dict(l=0.03, r=0, b=0),
-            height=FIRST_LINE_HEIGHT)
+            height=FIRST_LINE_HEIGHT,
+            geo_projection_scale=1.26)
     fig.update_traces(
             hovertemplate=hovertemplate,
         )


### PR DESCRIPTION
Partially addresses some points of #50 (map difficult to use): I removed most of the buttons of the modebar, and made it always visible (before it was only visible on hover, which is plotly's default).

To be discussed : should we disable the scroll-on-zoom and let users zoom only with + and - buttons if this is confusing?