### PR TITLE
Aligned "drag handles..." to center

### DIFF
--- a/make_figures.py
+++ b/make_figures.py
@@ -188,7 +188,7 @@ def make_timeplot(df_measure, df_prediction):
             font_size=LABEL_FONT_SIZE,
             text="Active cases")
     fig.add_annotation(
-            x=0.25,
+            x=1,
             y=-0.13,
             xref='paper',
             yref='paper',
@@ -196,7 +196,7 @@ def make_timeplot(df_measure, df_prediction):
             font_size=LABEL_FONT_SIZE - 6,
             font_color="DarkSlateGray",
             text="Drag handles below to change time window",
-            align="center")
+            align="right")
 
     return fig
 

--- a/make_figures.py
+++ b/make_figures.py
@@ -195,7 +195,8 @@ def make_timeplot(df_measure, df_prediction):
             showarrow=False,
             font_size=LABEL_FONT_SIZE - 6,
             font_color="DarkSlateGray",
-            text="Drag handles below to change time window")
+            text="Drag handles below to change time window",
+            align="center")
 
     return fig
 


### PR DESCRIPTION
The text which describes the time window slider is not aligned properly (Namely, "Drag handles below to change time window") - aligning to the center makes it look better.