### PR TITLE
remove red background color in selected cell

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -547,3 +547,12 @@ div.date {
     text-align: right;
     display: inline-block;
 }
+
+/*Disable red background color when selecting table cell */
+.dash-spreadsheet-container .dash-spreadsheet-inner table {
+	--accent: transparent  !important;
+        --selected-background: rgb(231, 231, 231) !important;
+        --muted: transparent !important;
+}
+
+


### PR DESCRIPTION
This is a tiny cosmetic improvement. I could not find how to keep the same background color as unselected cells (since odd and even rows have a different bg color), so I chose a light grey for selected cells of all rows, which is a much lighter visual cue than the red background color.

Not high priority though :-).